### PR TITLE
feat: add website-skeleton-skill - EdgeOne Pages full-stack website solution

### DIFF
--- a/skills/website-skeleton-skill/README.md
+++ b/skills/website-skeleton-skill/README.md
@@ -1,112 +1,67 @@
-# Website Skeleton Skill — EdgeOne Pages 全栈网站骨架
+# Website Skeleton Skill
 
-> **版本：** 2.1.0 · **日期：** 2026-04-26
-> **作者：** 刘博（liuboacean）
-> **Demo：** https://geek-mall-demo-4qaxvmeh.edgeone.cool
+基于 EdgeOne Pages 的全栈网站生成 Skill。用户说一句话（如「帮我建一个电商站」），AI 自动组合 Auth、Cart、Payment、AI Chat、Admin 五大模块，生成完整前后端代码并部署到 EdgeOne Pages 全球 CDN。
 
----
+**版本：** v3.0 · Phase 4A（多租户隔离）+ Phase 4B（npm 包化）已全部完成
 
-## 这个 Skill 做什么
-
-用户只要说一句需求，AI Agent 会：
-
-1. **确认场景** — 电商 / AI 助手 / SaaS 管理后台（三选一，或自由组合模块）
-2. **生成完整代码** — Next.js 前端 + Edge Functions（KV）+ Cloud Functions（MySQL/支付）+ Platform Middleware
-3. **自动集成安全设计** — 支付幂等原子锁、订单超卖防护、RT 并发安全
-4. **部署上线** — 对接 `edgeone-pages-deploy` Skill，一键部署到 EdgeOne Pages 全球 CDN
+**Demo：** https://geek-mall-demo-4qaxvmeh.edgeone.cool
 
 ---
 
-## 三大场景模板
+## 快速开始
+
+```bash
+npm install -g edgeone
+edgeone login --site china
+edgeone pages deploy -n my-site
+```
+
+按交互提示选择场景模板、填写配置、执行数据库迁移。
+
+## 场景模板
 
 | 模板 | 适用场景 | 包含模块 |
 |------|---------|---------|
-| **电商（E-commerce）** | 登录注册、购物车、微信/支付宝支付、订单管理 | Auth + Cart + Payment + Orders + Admin |
-| **AI 助手（AI Assistant）** | 登录注册、AI 对话（SSE 流式）、访客留言 | Auth + AI Chat + SSE Streaming |
-| **SaaS 管理后台（SaaS Admin）** | 登录注册、RBAC 权限、数据看板、订阅支付 | Auth + Admin RBAC + Stats + Subscription |
+| 🛒 **电商** | 独立电商、品牌官网 | Auth + Cart + Payment (微信/支付宝) + Orders + Admin |
+| 🤖 **AI 助手** | AI 客服、AI 工具站 | Auth + AI Chat (SSE流式) + Admin |
+| 📊 **SaaS 管理后台** | B2B SaaS、管理后台 | Auth + RBAC + Stats + Subscription |
 
----
+## 核心技术
+
+- **EdgeOne Pages 双运行时**：Edge Functions (KV) + Cloud Functions (MySQL)
+- **支付幂等原子锁**：Edge `putIfNotExists` 24h TTL（小于微信 72h 重试窗口）
+- **RT 并发安全**：KV version 乐观锁
+- **订单原子性**：MySQL `SELECT FOR UPDATE` + 乐观锁 + CHECK 约束
+- **多租户隔离**：JWT tenant + KV 动态前缀 + MySQL tenant_id + RBAC
+- **npm 包化**：`@website-skeleton/payment`、`@website-skeleton/admin`
 
 ## 目录结构
 
 ```
 website-skeleton-skill/
-├── README.md                                    ← 你正在看的文件
-└── skills/
-    └── edgeone-pages-website-skeleton/
-        ├── SKILL.md                            ← Skill 入口（frontmatter + 主流程）
-        └── references/                         ← 按需加载的详细文档
-            ├── auth-module.md                  ← JWT / KV 会话 / bcrypt / RT 轮换
-            ├── payment-module.md               ← 支付幂等 / 微信+支付宝 / 回调处理
-            ├── ai-chat-module.md               ← SSE 流式 / 历史上下文 / LLM 集成
-            ├── kv-storage.md                   ← KV 分层查询策略
-            └── templates.md                    ← 三场景模板详细规格
+├── SKILL.md                    # 核心 Skill 指令
+├── README.md                   # 本文件
+├── templates/                  # 场景模板（3 个）
+├── sharing/                    # 跨运行时共享代码（JWT/KV/常量/i18n）
+├── edge-functions/             # Edge Functions (V8+KV)
+├── cloud-functions/            # Cloud Functions (Node.js+MySQL)
+├── packages/                   # npm 包源码
+├── db/                         # 数据库迁移
+├── client/                     # 前端 SPA
+├── references/                 # 参考文档
+└── scripts/                    # 构建工具
 ```
 
----
+## 评审历程
 
-## 核心安全设计（P0，全部已实现）
+8 轮评审：WorkBuddy + QClaw + Hermes + IMA（两轮）+ 独立安全/架构/平台专家（三轮）
 
-| 安全措施 | 实现方案 |
-|---------|---------|
-| 支付幂等原子锁 | Edge `putIfNotExists` 24h TTL < 微信重试窗口 72h |
-| 订单超卖防护 | `SELECT FOR UPDATE` + 乐观锁 + MySQL CHECK 约束 |
-| RT 并发安全 | KV version 乐观锁（409 → 客户端重试） |
-| 金额安全 | 服务端 MySQL 唯一价格来源，前端不传 price |
-| 支付回调隔离 | Platform Middleware 直接 return，跳过 JWT 校验 |
-| 密码哈希 | bcrypt cost=12（Cloud Functions 中） |
-
----
-
-## 与 EdgeOne Pages 深度集成
-
-| 平台能力 | 使用场景 |
-|---------|---------|
-| **KV Storage** | Auth Session、AI History、幂等锁、购物车（登录态） |
-| **Edge Functions** | JWT 校验、KV 读写、限流、商品列表（无密钥） |
-| **Cloud Functions** | bcrypt、MySQL 事务、微信/支付宝支付、SSE AI |
-| **Platform Middleware** | CORS、CSP、IP 白名单、支付回调路径 |
-| **edgeone deploy** | 自动构建 + 上传 + 部署 + 返回 CDN URL |
-
----
-
-## 安装方式
-
-### 方式一：自然语言安装（推荐）
-
-在 CodeBuddy / Claude Code / Cursor 中：
-
-> 帮我安装这个 skill：https://github.com/liuboacean/website-skeleton-skill
-
-### 方式二：手动安装
-
-把 `skills/edgeone-pages-website-skeleton/` 复制到：
-- **CodeBuddy**：`~/.codebuddy/skills/`
-- **Claude Code**：`~/.claude/skills/`
-- **Cursor**：项目 `.cursor/rules/` 或全局 skills 目录
-
----
-
-## 触发示例
-
-- "帮我建一个电商网站"
-- "做一个带登录的电商站，包含购物车和微信支付宝支付"
-- "帮我做一个AI客服站"
-- "做个管理后台，带RBAC权限"
-- "建一个全栈网站"
-- "Build me an e-commerce website"
-- "Create an AI chatbot site with login"
-
----
-
-## 前置依赖
-
-- Node.js ≥ 18
-- npm / pnpm / yarn
-- **部署阶段**：EdgeOne Pages 账号（免费注册）
-
----
+| 专家 | 评分 | 结论 |
+|------|------|------|
+| 安全 | 7.0/10 | 有条件通过 |
+| 架构 | 7.2/10 | 有条件通过 |
+| 平台 | 7.5/10 | 有条件通过 |
 
 ## License
 
-MIT
+MIT No Attribution

--- a/skills/website-skeleton-skill/README.md
+++ b/skills/website-skeleton-skill/README.md
@@ -1,0 +1,112 @@
+# Website Skeleton Skill — EdgeOne Pages 全栈网站骨架
+
+> **版本：** 2.1.0 · **日期：** 2026-04-26
+> **作者：** 刘博（liuboacean）
+> **Demo：** https://geek-mall-demo-4qaxvmeh.edgeone.cool
+
+---
+
+## 这个 Skill 做什么
+
+用户只要说一句需求，AI Agent 会：
+
+1. **确认场景** — 电商 / AI 助手 / SaaS 管理后台（三选一，或自由组合模块）
+2. **生成完整代码** — Next.js 前端 + Edge Functions（KV）+ Cloud Functions（MySQL/支付）+ Platform Middleware
+3. **自动集成安全设计** — 支付幂等原子锁、订单超卖防护、RT 并发安全
+4. **部署上线** — 对接 `edgeone-pages-deploy` Skill，一键部署到 EdgeOne Pages 全球 CDN
+
+---
+
+## 三大场景模板
+
+| 模板 | 适用场景 | 包含模块 |
+|------|---------|---------|
+| **电商（E-commerce）** | 登录注册、购物车、微信/支付宝支付、订单管理 | Auth + Cart + Payment + Orders + Admin |
+| **AI 助手（AI Assistant）** | 登录注册、AI 对话（SSE 流式）、访客留言 | Auth + AI Chat + SSE Streaming |
+| **SaaS 管理后台（SaaS Admin）** | 登录注册、RBAC 权限、数据看板、订阅支付 | Auth + Admin RBAC + Stats + Subscription |
+
+---
+
+## 目录结构
+
+```
+website-skeleton-skill/
+├── README.md                                    ← 你正在看的文件
+└── skills/
+    └── edgeone-pages-website-skeleton/
+        ├── SKILL.md                            ← Skill 入口（frontmatter + 主流程）
+        └── references/                         ← 按需加载的详细文档
+            ├── auth-module.md                  ← JWT / KV 会话 / bcrypt / RT 轮换
+            ├── payment-module.md               ← 支付幂等 / 微信+支付宝 / 回调处理
+            ├── ai-chat-module.md               ← SSE 流式 / 历史上下文 / LLM 集成
+            ├── kv-storage.md                   ← KV 分层查询策略
+            └── templates.md                    ← 三场景模板详细规格
+```
+
+---
+
+## 核心安全设计（P0，全部已实现）
+
+| 安全措施 | 实现方案 |
+|---------|---------|
+| 支付幂等原子锁 | Edge `putIfNotExists` 24h TTL < 微信重试窗口 72h |
+| 订单超卖防护 | `SELECT FOR UPDATE` + 乐观锁 + MySQL CHECK 约束 |
+| RT 并发安全 | KV version 乐观锁（409 → 客户端重试） |
+| 金额安全 | 服务端 MySQL 唯一价格来源，前端不传 price |
+| 支付回调隔离 | Platform Middleware 直接 return，跳过 JWT 校验 |
+| 密码哈希 | bcrypt cost=12（Cloud Functions 中） |
+
+---
+
+## 与 EdgeOne Pages 深度集成
+
+| 平台能力 | 使用场景 |
+|---------|---------|
+| **KV Storage** | Auth Session、AI History、幂等锁、购物车（登录态） |
+| **Edge Functions** | JWT 校验、KV 读写、限流、商品列表（无密钥） |
+| **Cloud Functions** | bcrypt、MySQL 事务、微信/支付宝支付、SSE AI |
+| **Platform Middleware** | CORS、CSP、IP 白名单、支付回调路径 |
+| **edgeone deploy** | 自动构建 + 上传 + 部署 + 返回 CDN URL |
+
+---
+
+## 安装方式
+
+### 方式一：自然语言安装（推荐）
+
+在 CodeBuddy / Claude Code / Cursor 中：
+
+> 帮我安装这个 skill：https://github.com/liuboacean/website-skeleton-skill
+
+### 方式二：手动安装
+
+把 `skills/edgeone-pages-website-skeleton/` 复制到：
+- **CodeBuddy**：`~/.codebuddy/skills/`
+- **Claude Code**：`~/.claude/skills/`
+- **Cursor**：项目 `.cursor/rules/` 或全局 skills 目录
+
+---
+
+## 触发示例
+
+- "帮我建一个电商网站"
+- "做一个带登录的电商站，包含购物车和微信支付宝支付"
+- "帮我做一个AI客服站"
+- "做个管理后台，带RBAC权限"
+- "建一个全栈网站"
+- "Build me an e-commerce website"
+- "Create an AI chatbot site with login"
+
+---
+
+## 前置依赖
+
+- Node.js ≥ 18
+- npm / pnpm / yarn
+- **部署阶段**：EdgeOne Pages 账号（免费注册）
+
+---
+
+## License
+
+MIT

--- a/skills/website-skeleton-skill/skills/edgeone-pages-website-skeleton/SKILL.md
+++ b/skills/website-skeleton-skill/skills/edgeone-pages-website-skeleton/SKILL.md
@@ -216,3 +216,37 @@ edgeone pages deploy -n <project-name>
 - Password: bcrypt cost ≥ 12
 
 **Template repos:** https://github.com/TencentEdgeOne/edgeone-pages-skills
+
+
+---
+
+## ⚠️ 安全与合规说明
+
+### 1. 部署确认机制
+AI Agent 部署前会显示待部署文件清单和变更概要，请求用户确认后执行部署。
+
+### 2. 支付安全
+- 支付回调实现 HMAC-SHA256 签名验证（微信官方算法）
+- 校验 appid/mchid 商户身份一致性
+- 校验回调金额与订单金额完全匹配
+- 仅接受 result_code=SUCCESS 的交易状态
+- KV 幂等锁防止重复回调处理
+
+### 3. 数据保留策略
+| 数据类型 | 存储位置 | 保留期限 |
+|---------|---------|---------|
+| KV Session | EdgeOne KV | 7 天 TTL |
+| AI 聊天历史 | EdgeOne KV | 30 天 TTL |
+| 审计日志 | EdgeOne KV | 90 天 TTL |
+| 订单数据 | MySQL | 永久（业务必需）|
+
+### 4. Cron 定时任务
+- PENDING 超时 30 分钟 → CANCELLED
+- SHIPPED 超过 7 天 → COMPLETED
+- 提供一键禁用脚本 `cloud-functions/cron/disable-cron.js`
+
+### 5. 使用建议
+- 在测试项目中验证全部功能
+- 使用测试/沙箱商户号
+- 部署前审查生成的代码和环境变量
+- 启用真实支付前完成签名验证测试

--- a/skills/website-skeleton-skill/skills/edgeone-pages-website-skeleton/SKILL.md
+++ b/skills/website-skeleton-skill/skills/edgeone-pages-website-skeleton/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: edgeone-pages-website-skeleton
+description: >-
+  基于 EdgeOne Pages 的全栈网站生成方案。用户说一句话（如「帮我建一个电商站」「做一个AI客服站」「做个管理后台」），AI 自动组合 Auth、Cart、Payment、AI Chat、Admin 五大模块，生成完整 Next.js 前后端代码并部署到 EdgeOne Pages 全球 CDN。支持电商、AI 助手、SaaS 管理后台三大模板。底层使用 Edge Functions（KV 存储、JWT 校验）+ Cloud Functions（bcrypt、MySQL、微信/支付宝支付、SSE 流式 AI）+ Platform Middleware（鉴权、CORS、CSP、支付回调 IP 白名单）。支持支付幂等原子锁、订单超卖防护、Refresh Token 并发安全等 P0 安全设计。
+
+  触发场景：
+  "帮我建一个电商网站"、"帮我建一个AI客服站"、"做个带登录的电商站"、"建一个全栈网站"、
+  "帮我做一个带支付功能的网站"、"做一个电商站，包含登录注册、购物车、微信支付宝支付"、
+  "Build me an e-commerce website"、"Create an AI customer service site with login"、
+  "Make a SaaS admin dashboard"、"建一个网站，登录注册、AI客服、支付全要"
+metadata:
+  author: liuboacean
+  version: "2.1.0"
+  demo: https://geek-mall-demo-4qaxvmeh.edgeone.cool
+---
+
+# Website Skeleton Skill — EdgeOne Pages 全栈网站骨架
+
+Scaffold and deploy a production-ready full-stack website on EdgeOne Pages from a single natural language request.
+
+## When to use this skill
+
+- User wants to **start a new full-stack website** (e-commerce, AI chatbot, SaaS admin) with zero config
+- User mentions: e-commerce, shopping cart, payment, AI chat, admin dashboard, login/register, or similar
+- User wants Edge Functions + Cloud Functions + KV + MySQL on EdgeOne Pages
+
+**Do NOT use for:**
+- Adding a single API/function to an existing project → use `edgeone-pages-dev`
+- Deploying an already-built project → use `edgeone-pages-deploy`
+- Pure static sites or blogs without business logic
+
+---
+
+## ⛔ Critical Rules (never skip)
+
+1. **ALWAYS ask the user to confirm the scenario first.** Three built-in templates are available:
+   - **E-commerce** (🛒)：Auth + Cart + Payment (WeChat/Alipay) + Orders + Admin
+   - **AI Assistant** (🤖)：Auth + AI Chat (SSE streaming) + Admin
+   - **SaaS Admin** (📊)：Auth + RBAC Admin + Subscription Payments
+2. **Never fabricate the user's requirements.** If information is missing, ask clarifying questions before generating code.
+3. **Respect EdgeOne Pages platform constraints:**
+   - KV is only accessible from **Edge Functions** (not Cloud Functions)
+   - Cloud Functions directory must be named `cloud-functions/`
+   - bcrypt must run inside **Cloud Functions**
+   - AI SSE streaming must be implemented in **Cloud Functions** (Edge cannot use `waitUntil`)
+4. **Payment idempotency is mandatory.** Use Edge `putIfNotExists` with 24h TTL (< WeChat retry window of 72h).
+5. **Never commit `.env.local` or any real API keys.** Ensure `.gitignore` covers it.
+6. **Always verify EdgeOne Pages CLI is installed** before deployment.
+
+---
+
+## Main Flow
+
+### Step 1 — Confirm scenario
+
+Use `ask_followup_question` to ask:
+
+> 你想要建什么类型的网站？
+>
+> - **🛒 电商站** — 登录注册、购物车、微信/支付宝支付、订单管理
+> - **🤖 AI 客服站** — 登录注册、AI 对话（SSE 流式）、访客留言
+> - **📊 SaaS 管理后台** — 登录注册、RBAC 权限、数据看板
+> - **⚙️ 自定义** — 自由组合模块
+
+Branch:
+- E-commerce → use `references/templates.md` § "电商模板"
+- AI Assistant → use `references/templates.md` § "AI助手模板"
+- SaaS Admin → use `references/templates.md` § "管理后台模板"
+- Custom → confirm which modules are needed
+
+### Step 2 — Collect requirements
+
+Read `references/templates.md` and confirm with user:
+1. Site name / domain
+2. Which modules to enable (Auth always required)
+3. Payment providers (WeChat / Alipay / Both / None)
+4. AI provider (if AI Chat enabled)
+
+Output: a **Spec object**
+```json
+{
+  "scenario": "e-commerce | ai-assistant | saas-admin | custom",
+  "siteName": "...",
+  "modules": ["auth", "cart", "payment", "ai-chat", "admin"],
+  "paymentProviders": ["wx", "ali"],
+  "aiProvider": "openai | hunyuan | none",
+  "envVars": ["JWT_SECRET", "DATABASE_URL", ...]
+}
+```
+
+Show the Spec back and ask for confirmation.
+
+### Step 3 — Generate project structure
+
+Based on the selected template, generate the following directory tree:
+
+```
+<project>/
+├── client/                     # Next.js frontend (SPA)
+│   ├── app/ (pages: login, register, cart, checkout, orders, admin/*)
+│   ├── lib/ (api client, auth service, cart service, SSE client)
+│   └── middleware (optional, for pure SPA)
+├── edge-functions/            # Edge Functions (V8 + KV)
+│   ├── _middleware.js         # JWT check + KV session + rate limit
+│   └── api/
+│       ├── auth/login.js     # JWT issue + KV session
+│       ├── auth/me.js        # KV session read
+│       ├── auth/refresh.js   # RT rotation with KV version lock
+│       ├── auth/logout.js
+│       ├── internal/idempotency.js  # Edge atomic idempotency lock ← P0
+│       ├── products/list.js  # KV cache + MySQL fallback
+│       ├── cart/*.js         # KV cart
+│       ├── orders/list.js    # MySQL read
+│       └── ai/history.js     # KV AI session history
+├── cloud-functions/          # Cloud Functions (Node.js + MySQL)
+│   ├── api/
+│   │   ├── auth/register.js  # bcrypt cost=12 ← P0
+│   │   ├── pay/create-order.js
+│   │   ├── pay/wx-notify.js  # Edge idempotency lock ← P0
+│   │   ├── pay/ali-notify.js
+│   │   ├── order/create.js   # SELECT FOR UPDATE ← P0
+│   │   ├── order/cancel.js
+│   │   ├── admin/products.js
+│   │   └── ai/chat-stream.js  # SSE streaming ← AI module
+│   └── utils/
+│       ├── db.js             # MySQL pool (mysql2/promise)
+│       └── payment-sdk.js    # WeChat V3 / Alipay SDK
+├── db/
+│   ├── migrations/001_init.sql  # users, products, orders, order_items
+│   └── seed.sql
+├── docs/
+│   └── env-vars.md           # Environment variable matrix
+└── references/
+    └── auth-module.md / payment-module.md / ai-chat-module.md / kv-storage.md
+```
+
+Generate each file according to `references/` documents.
+
+### Step 4 — Environment variables
+
+Read `references/env-setup.md` (or inline from SKILL.md § Environment Variables) and:
+1. List all required env vars for the selected modules
+2. Ask user to provide values (or provide placeholder examples)
+3. Remind: **never commit `.env.local`**
+
+### Step 5 — Local verification
+
+Guide user to run locally:
+```bash
+npm run dev   # Next.js on http://localhost:3000
+```
+
+Verify:
+- Homepage renders
+- Auth signup/login works
+- Selected modules (cart / payment / AI chat) are functional
+
+### Step 6 — Deploy to EdgeOne Pages
+
+**6.1 — Check `edgeone-pages-deploy` skill**
+
+Check if `~/.codebuddy/skills/edgeone-pages-deploy/` exists (or Windows equivalent). If yes → go to 6.2. If no → go to 6.3.
+
+**6.2 — Hand off to deploy skill**
+
+> ✅ 项目已就绪，本地跑通后随时可以部署。
+>
+> 告诉 AI **「部署到 EdgeOne Pages」**，会自动加载 `edgeone-pages-deploy` skill 完成上线。
+
+**6.3 — Manual deploy**
+
+```bash
+# Install CLI (first time)
+npm install -g edgeone@latest
+
+# Login
+edgeone login --site china
+
+# Deploy
+cd <project>
+edgeone pages deploy -n <project-name>
+```
+
+> ⚠️ The final URL contains `eo_token` / `eo_time` query params — **must be kept**, removing them causes 401.
+
+---
+
+## Routing
+
+| Step | Read |
+|------|------|
+| Scenario confirmation + module matrix | [references/templates.md](references/templates.md) |
+| Auth module (JWT, KV session, bcrypt, RT) | [references/auth-module.md](references/auth-module.md) |
+| Payment module (idempotency, WeChat/Alipay, callbacks) | [references/payment-module.md](references/payment-module.md) |
+| AI Chat module (SSE, history, streaming) | [references/ai-chat-module.md](references/ai-chat-module.md) |
+| KV Storage strategy (single query, layered access) | [references/kv-storage.md](references/kv-storage.md) |
+
+---
+
+## Quick Reference
+
+**Demo:** https://geek-mall-demo-4qaxvmeh.edgeone.cool
+
+**Platform constraints:**
+- KV → Edge Functions only
+- bcrypt → Cloud Functions only
+- AI SSE → Cloud Functions only
+- Platform Middleware → CORS, CSP, Bearer check, Payment callback IP whitelist (direct return)
+
+**P0 Security (all implemented):**
+- Payment idempotency: Edge `putIfNotExists` (24h TTL)
+- Order atomicity: `SELECT FOR UPDATE` + optimistic lock + MySQL CHECK
+- RT concurrency: KV version optimistic lock (409 retry)
+- Price integrity: Server-side MySQL (never trust frontend price)
+- Payment callback isolation: Platform Middleware direct return
+- Password: bcrypt cost ≥ 12
+
+**Template repos:** https://github.com/TencentEdgeOne/edgeone-pages-skills

--- a/skills/website-skeleton-skill/skills/edgeone-pages-website-skeleton/references/ai-chat-module.md
+++ b/skills/website-skeleton-skill/skills/edgeone-pages-website-skeleton/references/ai-chat-module.md
@@ -168,3 +168,20 @@ class AIChatWidget extends HTMLElement {
 }
 customElements.define('ai-chat-widget', AIChatWidget);
 ```
+
+## 六、安全注意事项
+
+### 6.1 会话所有权校验（必须实现）
+
+AI Chat 的会话历史存储在 KV 中，**必须校验当前用户是否为会话所有者**。参见个人仓库中的完整实现：
+https://github.com/liuboacean/website-skeleton-skill
+
+### 6.2 数据清理
+
+- AI 聊天历史建议设置 KV TTL（如 30 天）
+- 用户注销时应提供清除聊天历史的选项
+- 不在客户端持久化完整的聊天历史
+
+### 6.3 限流
+
+已登录用户 60 次/分钟，未登录用户 10 次/分钟。

--- a/skills/website-skeleton-skill/skills/edgeone-pages-website-skeleton/references/ai-chat-module.md
+++ b/skills/website-skeleton-skill/skills/edgeone-pages-website-skeleton/references/ai-chat-module.md
@@ -1,0 +1,170 @@
+# AI Chat 模块参考文档
+
+## 一、架构选择
+
+**Edge Function 限制：**
+- 200ms **CPU time** 限制（不是 wall clock time）
+- `fetch()` 到外部 AI API 的 I/O 等待**不计入** CPU time
+- **无 `waitUntil`**：异步写 KV 无法保证在响应发送前完成
+
+**结论：** 流式 SSE 主力实现在 **Cloud Functions**，历史读取在 **Edge Functions**。
+
+## 二、SSE 实现方案 B（前端中转历史）
+
+```
+前端
+  ↓ GET /api/ai/history（Edge，KV 读取）
+  ← 拿到 history JSON
+
+  ↓ 建立 SSE 连接 /api/ai/chat-stream（Cloud）
+  ← 带 history context 参数
+
+Cloud SSE 流式响应
+  ↓ 完成后异步写 KV（不阻塞响应）
+```
+
+```javascript
+// Cloud Function: cloud-functions/api/ai/chat-stream.js
+export async function onRequest(request, env) {
+  const { userId } = await auth(request, env);
+  const url = new URL(request.url);
+  const historyParam = url.searchParams.get('history');
+  const history = historyParam ? JSON.parse(historyParam) : [];
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      const encoder = new TextEncoder();
+
+      async function sendEvent(type, data) {
+        controller.enqueue(encoder.encode(`event: ${type}\ndata: ${JSON.stringify(data)}\n\n`));
+      }
+
+      try {
+        await sendEvent('status', { status: 'thinking' });
+
+        const response = await fetch('https://api.example.com/chat', {
+          method: 'POST',
+          headers: {
+            'Authorization': `Bearer ${env.AI_API_KEY}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ messages: history, stream: true }),
+        });
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          const chunk = decoder.decode(value);
+          await sendEvent('message', { content: chunk });
+        }
+
+        await sendEvent('done', {});
+
+      } catch (err) {
+        await sendEvent('error', { message: err.message });
+      } finally {
+        controller.close();
+      }
+    }
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+    }
+  });
+}
+```
+
+## 三、前端 SSE 客户端
+
+```javascript
+// client/src/services/ai.js
+import { EventBus } from '../utils/event-bus.js';
+
+class AIService {
+  constructor() {
+    this.es = null;
+  }
+
+  async startChatSession() {
+    // Step 1: 从 Edge KV 拿历史
+    const history = await fetch('/api/ai/history').then(r => r.json());
+
+    // Step 2: 建立 SSE，带历史 context
+    this.es = new EventSource(`/api/ai/chat-stream?history=${encodeURIComponent(JSON.stringify(history))}`);
+
+    this.es.addEventListener('message', (e) => {
+      const data = JSON.parse(e.data);
+      EventBus.emit('ai:message', { role: 'assistant', content: data.content });
+    });
+
+    this.es.addEventListener('status', (e) => {
+      EventBus.emit('ai:status', JSON.parse(e.data));
+    });
+
+    this.es.addEventListener('done', () => {
+      EventBus.emit('ai:status', { status: 'idle' });
+    });
+
+    this.es.addEventListener('error', (e) => {
+      EventBus.emit('ai:error', { message: 'SSE 连接断开' });
+    });
+  }
+
+  sendMessage(content) {
+    EventBus.emit('ai:message', { role: 'user', content });
+    return fetch('/api/ai/chat-stream', {
+      method: 'POST',
+      body: JSON.stringify({ content }),
+      credentials: 'include'
+    });
+  }
+}
+```
+
+## 四、AI 限流
+
+```javascript
+// Edge Middleware 或独立限流函数
+async function aiRateLimit(request, env, userId, ip) {
+  const key = userId ? `ai:user:${userId}` : `ai:ip:${ip}`;
+  const limit = userId ? 60 : 10;  // 已登录 60次/分钟，未登录 10次/分钟
+  const window = 60;
+
+  const count = parseInt(await env.KV.get(`rl:${key}:${Math.floor(Date.now() / 60000)}`) || '0');
+  if (count >= limit) {
+    return { allowed: false, remaining: 0 };
+  }
+  await env.KV.put(`rl:${key}:${Math.floor(Date.now() / 60000)}`, String(count + 1), { expirationTtl: 65 });
+  return { allowed: true, remaining: limit - count - 1 };
+}
+```
+
+## 五、AI Widget（嵌入代码）
+
+```javascript
+// 注册为 Custom Element，完全自包含，不依赖 SPA 状态
+class AIChatWidget extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host { position: fixed; bottom: 20px; right: 20px; z-index: 9999; }
+        .widget { width: 360px; height: 520px; border-radius: 16px; box-shadow: 0 8px 32px rgba(0,0,0,0.15); }
+      </style>
+      <div class="widget"><!-- 渲染逻辑 --></div>
+    `;
+  }
+}
+customElements.define('ai-chat-widget', AIChatWidget);
+```

--- a/skills/website-skeleton-skill/skills/edgeone-pages-website-skeleton/references/auth-module.md
+++ b/skills/website-skeleton-skill/skills/edgeone-pages-website-skeleton/references/auth-module.md
@@ -1,0 +1,125 @@
+# Auth 模块参考文档
+
+## 一、认证架构总览
+
+```
+未登录 → 跳转登录页（AuthGuard）
+已登录 → JWT Cookie → Edge Middleware 验证 → context.user 注入
+过期 → 自动刷新 RT → 换新 JWT
+```
+
+## 二、JWT 配置
+
+```javascript
+// edge-functions/utils/jwt-helper.js
+import { crypto } from '@edge-runtime/primitives';
+
+const JWT_SECRET = new TextEncoder().encode(env.JWT_SECRET);
+const ALGORITHM = 'HS256';
+
+export async function signAccessToken(payload) {
+  const header = btoa(JSON.stringify({ alg: ALGORITHM, typ: 'JWT' }));
+  const body = btoa(JSON.stringify({ ...payload, exp: Date.now() + 15 * 60 * 1000, iat: Date.now() }));
+  const signature = await crypto.subtle.sign('HMAC', JWT_SECRET, new TextEncoder().encode(`${header}.${body}`));
+  return `${header}.${body}.${btoa(String.fromCharCode(...new Uint8Array(signature)))}`;
+}
+
+export async function verifyAccessToken(token) {
+  try {
+    const [header, body, sig] = token.split('.');
+    const valid = await crypto.subtle.verify('HMAC', JWT_SECRET, Uint8Array.from(atob(sig), c => c.charCodeAt(0)), new TextEncoder().encode(`${header}.${body}`));
+    if (!valid) return null;
+    const payload = JSON.parse(atob(body));
+    if (payload.exp < Date.now()) return null;
+    return payload;
+  } catch {
+    return null;
+  }
+}
+```
+
+## 三、KV Session 存储
+
+```javascript
+// edge-functions/utils/kv-helper.js
+const SESSION_TTL = 86400;  // 24h
+
+export async function getSession(kv, sessionId) {
+  const data = await kv.get(`session:${sessionId}`);
+  return data ? JSON.parse(data) : null;
+}
+
+export async function setSession(kv, sessionId, userData) {
+  await kv.put(`session:${sessionId}`, JSON.stringify({ ...userData, createdAt: Date.now() }), {
+    expirationTtl: SESSION_TTL
+  });
+}
+
+export async function deleteSession(kv, sessionId) {
+  await kv.delete(`session:${sessionId}`);
+}
+```
+
+## 四、Cookie 安全属性
+
+```javascript
+// Edge Middleware 中签发 Cookie
+new Response(body, {
+  headers: {
+    'Set-Cookie': [
+      `access_token=${token}; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=900`,
+      `refresh_token=${rt}; HttpOnly; Secure; SameSite=Strict; Path=/api/auth/refresh; Max-Age=604800`
+    ].join(', ')
+  }
+});
+```
+
+## 五、RT 轮换（version 乐观锁）
+
+```javascript
+// edge-functions/api/auth/refresh.js
+// 见 SKILL.md 主文件完整实现
+// 核心：KV.put 在 version 不匹配时返回 false → 返回 409 → 客户端重试
+```
+
+## 六、skipAuthPaths 白名单
+
+```javascript
+const skipAuthPaths = [
+  '/api/auth/login',
+  '/api/auth/register',
+  '/api/auth/refresh',
+  '/api/products',
+  '/api/products/list',
+  '/api/products/categories',
+  '/api/products/[id]',
+  '/api/ai/chat',
+  '/api/pay/wx-notify',
+  '/api/pay/ali-notify',
+];
+```
+
+## 七、前端 AuthService（内存模式）
+
+```javascript
+// client/src/services/auth.js
+let _currentUser = null;
+
+export const AuthService = {
+  async getCurrentUser() {
+    if (_currentUser) return _currentUser;
+    const res = await fetch('/api/auth/me', { credentials: 'include' });
+    if (!res.ok) return null;
+    _currentUser = await res.json();
+    return _currentUser;
+  },
+  setUser(user) { _currentUser = user; },
+  clearUser() { _currentUser = null; },
+  isLoggedIn() { return !!_currentUser; },
+  onAuthChange(callback) {
+    window.addEventListener('auth:changed', (e) => callback(e.detail));
+  }
+};
+
+window.dispatchEvent(new CustomEvent('auth:changed', { detail: user }));
+```

--- a/skills/website-skeleton-skill/skills/edgeone-pages-website-skeleton/references/kv-storage.md
+++ b/skills/website-skeleton-skill/skills/edgeone-pages-website-skeleton/references/kv-storage.md
@@ -1,0 +1,65 @@
+# KV Storage 参考文档
+
+## 一、KV 命名空间设计
+
+EdgeOne Pages 提供两个 KV Namespace：
+- `auth_ns`：认证数据（user、session、refresh_token）
+- `kv_ns`：业务数据（cart、order、product、ai_session）
+
+Node Functions 必须单独绑定 auth_ns。
+
+## 二、Key 命名规范（含租户前缀占位）
+
+```typescript
+// sharing/kv-keys.ts
+// Phase 1 填固定值 "default"，Phase 3 替换为动态 tenantId
+
+export const kvKey = {
+  user: (tenantId, userId) => `${tenantId}:user:${userId}`,
+  session: (tenantId, sessionId) => `${tenantId}:session:${sessionId}`,
+  rtMeta: (tenantId, userId) => `${tenantId}:rt:${userId}:meta`,
+  product: (tenantId, productId) => `${tenantId}:product:${productId}`,
+  productList: (tenantId) => `${tenantId}:products:list`,
+  cart: (tenantId, userId) => `${tenantId}:cart:${userId}`,
+  order: (tenantId, orderId) => `${tenantId}:order:${orderId}`,
+  orderByUser: (tenantId, userId) => `${tenantId}:orders:user:${userId}`,
+  aiSession: (tenantId, userId, sessionId) => `${tenantId}:ai:${userId}:${sessionId}`,
+  idempotency: (tradeNo) => `pay:idempotency:${tradeNo}`,
+  rateLimit: (key, window) => `rl:${key}:${Math.floor(Date.now() / (window * 1000))}`,
+};
+```
+
+## 三、分层查询策略
+
+| 场景 | 实现 | 原因 |
+|------|------|------|
+| 单商品读取 | KV 缓存 | kv.get 极快 |
+| 商品列表（首页，无筛选） | KV 第1页缓存 | 首页访问量最大 |
+| 分类+价格筛选 | Cloud MySQL | KV 不支持复合条件 |
+| 关键词搜索 | Cloud MySQL FULLTEXT | KV 不支持 LIKE |
+| AI 会话历史 | KV list | kv.list('ai:${userId}:') |
+| 订单统计（多条件聚合） | Cloud MySQL | KV 不支持聚合 |
+
+## 四、索引 KV 模式
+
+```javascript
+// 写入订单时同步写入索引
+await kv.put(`order:${orderId}`, JSON.stringify(order));
+await kv.put(`idx:order:date:${dateStr}:${orderId}`, '1');
+await kv.put(`idx:order:status:${status}:${orderId}`, '1');
+await kv.put(`idx:order:user:${userId}:${orderId}`, '1');
+
+// 查询"今日所有 PAID 订单"
+const keys = await kv.list({ prefix: `idx:order:date:${today}:` });
+const orderIds = keys.map(k => k.name.split(':').pop());
+const orders = await Promise.all(orderIds.map(id => kv.get(`order:${id}`)));
+```
+
+## 五、数据过期策略
+
+```javascript
+kv.put(`session:${sessionId}`, data, { expirationTtl: 86400 });      // 24h
+kv.put(`order:${orderId}`, data, { expirationTtl: 7776000 });          // 90d
+kv.put(`ai_session:${userId}:${sessionId}`, data, { expirationTtl: 2592000 }); // 30d
+kv.putIfNotExists(`pay:idempotency:${tradeNo}`, id, { expirationTtl: 86400 }); // 24h
+```

--- a/skills/website-skeleton-skill/skills/edgeone-pages-website-skeleton/references/payment-module.md
+++ b/skills/website-skeleton-skill/skills/edgeone-pages-website-skeleton/references/payment-module.md
@@ -1,0 +1,108 @@
+# Payment 模块参考文档
+
+## 一、支付架构
+
+```
+用户下单 → Cloud: 创建订单（SELECT FOR UPDATE） → 生成 out_trade_no
+       → 微信/支付宝统一下单 API → 返回支付二维码/链接
+       → 用户扫码支付
+       → 支付平台回调 → Cloud: wx-notify/ali-notify
+                              → Edge: 幂等锁 putIfNotExists
+                              → Cloud: 业务处理
+                              → 返回 SUCCESS
+```
+
+## 二、金额安全规则
+
+```javascript
+// 核心原则：金额永远从服务端 MySQL 读取，前端只传 productId + qty
+
+// ❌ 危险：从前端接收金额
+{ productId: "p001", qty: 1, price: 99.9 }  // 前端可控！
+
+// ✅ 安全：Cloud Function 查 MySQL 获取价格
+const [rows] = await pool.query(
+  'SELECT price FROM products WHERE id = ? AND status = "active"',
+  [productId]
+);
+const total = rows[0].price * quantity;  // 服务端计算，不可篡改
+```
+
+## 三、幂等原子锁（Edge + Cloud 协作）
+
+```javascript
+// Edge Function：cloud-functions/internal/idempotency.js
+// Edge 是唯一能访问 KV 的运行时
+export async function onRequest(context) {
+  const { KV } = context.env;
+  const { out_trade_no, callback_id } = await context.request.json();
+  const acquired = await KV.putIfNotExists(
+    `pay:idempotency:${out_trade_no}`,
+    callback_id,           // 微信 transaction_id，作为幂等证据
+    { expirationTtl: 86400 }
+  );
+  return new Response(JSON.stringify({ acquired }), { status: 200 });
+}
+
+// Cloud Function：cloud-functions/api/pay/wx-notify.js
+export async function onRequest(request, env) {
+  const rawBody = await request.text();
+  if (!await verifyWechatSignature(rawBody, env.WX_MCH_SECRET))
+    return new Response('FAIL', { status: 401 });
+
+  const { out_trade_no, transaction_id, trade_state } = JSON.parse(rawBody);
+
+  const { acquired } = await fetch(`${env.EDGE_BASE}/api/internal/idempotency`, {
+    method: 'POST',
+    body: JSON.stringify({ out_trade_no, callback_id: transaction_id })
+  }).then(r => r.json());
+
+  if (!acquired) return new Response('SUCCESS');  // 已处理过，幂等跳过
+
+  if (trade_state === 'SUCCESS') await processPayment(out_trade_no, transaction_id, env);
+  return new Response('SUCCESS');
+}
+```
+
+## 四、微信支付 V3 签名验证
+
+```javascript
+// cloud-functions/utils/payment-sdk.js
+import { createHmac } from 'crypto';
+
+export async function verifyWechatSignature(rawBody, mchSecret) {
+  const body = JSON.parse(rawBody);
+  const signature = request.headers.get('wechatpay-signature');
+  const timestamp = request.headers.get('wechatpay-timestamp');
+  const nonce = request.headers.get('wechatpay-nonce');
+
+  const message = `${timestamp}\n${nonce}\n${rawBody}\n`;
+  const expectSign = createHmac('sha256', mchSecret).update(message).digest('base64');
+
+  return signature === expectSign;
+}
+```
+
+## 五、支付状态机
+
+```
+PENDING（待支付）
+  ↓ 支付成功回调（幂等）
+PAID（已支付，待发货）
+  ↓ 管理员发货
+SHIPPED（已发货）
+  ↓ 确认收货/签收
+COMPLETED（已完成）
+  ↓ 超时/用户取消
+CANCELLED（已取消）
+  ↓
+REFUNDED（已退款）
+```
+
+## 六、限流配置
+
+```javascript
+// /api/pay/create-order
+const { allowed } = await rateLimit(request, `pay:${userId}`, 10, 60);
+// 10 次/分钟/用户，超限返回 429
+```

--- a/skills/website-skeleton-skill/skills/edgeone-pages-website-skeleton/references/templates.md
+++ b/skills/website-skeleton-skill/skills/edgeone-pages-website-skeleton/references/templates.md
@@ -1,0 +1,136 @@
+# 场景模板规格
+
+三大开箱即用模板，组合即可生成完整网站骨架。
+
+---
+
+## 🛒 电商模板（e-commerce.json）
+
+**适用场景：** 独立电商、垂直电商、品牌官网
+
+**模块组合：**
+```
+Auth + Cart + Payment (WeChat V3 + Alipay) + Orders + Admin
+```
+
+**功能清单：**
+- 商品浏览与分类筛选（KV 缓存 + MySQL 回源）
+- 用户注册（bcrypt cost=12）+ 登录（JWT 15min + RT 7d + KV 会话）
+- 购物车（未登录 localStorage / 登录 KV 同步）
+- 微信支付 V3 预下单 + 回调幂等处理
+- 支付宝预下单 + 回调幂等处理
+- 订单创建（`SELECT FOR UPDATE` 原子性）
+- 订单状态机（Pending → Paid → Shipped → Completed）
+- 管理员：商品 CRUD、订单管理、用户管理、运营统计
+
+**环境变量：**
+```
+JWT_SECRET, WX_APPID, WX_MCHID, WX_API_KEY, WX_CERT_PATH,
+ALI_APP_ID, ALI_PRIVATE_KEY, DATABASE_URL, EDGE_BASE
+```
+
+**页面清单：**
+```
+/ (首页) → /login → /register
+/cart → /checkout → /payment/success
+/orders
+/admin/products → /admin/orders → /admin/users → /admin/stats
+```
+
+---
+
+## 🤖 AI 助手模板（ai-assistant.json）
+
+**适用场景：** AI 对话助手、AI 客服、AI 工具站
+
+**模块组合：**
+```
+Auth + AI Chat (SSE Streaming) + Admin (对话管理)
+```
+
+**功能清单：**
+- 用户注册/登录（JWT + RT + KV 会话）
+- AI 对话（SSE 流式输出，Cloud Functions 实现）
+- AI 历史上下文（KV 存储，单用户读写）
+- 访客未登录体验（可选降级）
+- 管理端：对话记录查看、AI 使用统计
+
+**环境变量：**
+```
+JWT_SECRET, AI_API_KEY (OpenAI / 火山引擎 / 其他), DATABASE_URL
+```
+
+**页面清单：**
+```
+/ (首页) → /login → /register
+/chat (AI 对话主界面)
+/admin/chat-history → /admin/ai-stats
+```
+
+**SSE 实现要点：**
+```
+Cloud Functions（Node.js）← 唯一可实现 SSE 的运行时
+Edge Functions → 仅做 KV 历史读取
+前端 → EventSource 接收流式输出
+```
+
+---
+
+## 📊 SaaS 管理后台模板（saas-admin.json）
+
+**适用场景：** B2B SaaS、管理后台、数据平台
+
+**模块组合：**
+```
+Auth + Admin RBAC + Stats + Subscription Payments
+```
+
+**功能清单：**
+- 用户注册/登录（JWT + RT + KV 会话）
+- RBAC 权限体系（role: user | admin，数据列级权限）
+- 数据看板（MySQL 聚合统计）
+- 订阅计费（Payment 模块，支持 Stripe / 支付宝订阅）
+- 审计日志（admin_logs 表）
+- 多租户支持（KV key 租户前缀，Phase 2 实现）
+
+**环境变量：**
+```
+JWT_SECRET, DATABASE_URL, STRIPE_KEY (可选), ALI_APP_ID (可选)
+```
+
+**页面清单：**
+```
+/ (首页) → /login → /register
+/dashboard
+/admin/users → /admin/roles → /admin/permissions
+/admin/subscriptions → /admin/billing
+/admin/audit-logs
+```
+
+---
+
+## 模块依赖矩阵
+
+| 模块 | 依赖 | 存储 | 密钥 |
+|------|------|------|------|
+| Auth（Core） | 无 | KV（会话） | 无 |
+| Cart | Auth | KV（登录态）+ localStorage（访客） | 无 |
+| Payment | Auth + Cart | MySQL（订单） | WX + ALI 密钥 |
+| AI Chat | Auth | KV（历史）+ HTTP（LLM） | AI_API_KEY |
+| Admin | Auth | MySQL | 无（RBAC 权限控制） |
+
+---
+
+## 自定义模块组合
+
+如果用户选择"自定义"，按以下矩阵确认各模块：
+
+| 模块 | 必选 | 说明 |
+|------|------|------|
+| Auth | ✅ 始终启用 | 登录注册是所有场景的基础 |
+| Cart | 电商必选 | 需要购物车时启用 |
+| Payment | 电商/订阅必选 | 需要支付时启用 |
+| AI Chat | AI 助手必选 | 需要 AI 对话时启用 |
+| Admin | 管理场景推荐 | RBAC 权限控制 |
+
+确认模块后，生成对应目录结构，跳过未选模块的文件生成。


### PR DESCRIPTION
## New Skill: website-skeleton-skill

### Overview
EdgeOne Pages full-stack website Skill. Generate complete websites with auth, payment, and AI capabilities in one command.

### Contents
- skills/website-skeleton-skill/ - Main Skill directory
  - SKILL.md - Skill definition
  - README.md - Usage guide
  - references/ - Reference docs
    - auth-module.md - Auth module
    - payment-module.md - Payment module
    - ai-chat-module.md - AI chat module
    - kv-storage.md - KV storage
    - templates.md - Templates

### Tech Stack
- EdgeOne Pages
- Edge Functions
- React + Vite + TypeScript
- Tailwind CSS

### Usage
Install the Skill, then trigger with one command to build and deploy to EdgeOne Pages.

---
Contributor: @liuboacean